### PR TITLE
Pass namespaces to the validateXPath function

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -256,12 +256,19 @@
 			return true;
 		}
 		
-		public function validateXPath($expression) {
+		public function validateXPath($expression, $namespaces = array()) {
 			$document = new DOMDocument();
 			$document->loadXML('<data />');
 			$xpath = new DOMXPath($document);
 			$html_errors = ini_get('html_errors');
 			$exception = null;
+			
+			// Register namespaces:
+			if (is_array($namespaces)) {
+				foreach ($namespaces as $namespace) {
+					$xpath->registerNamespace($namespace['name'], $namespace['uri']);
+				}
+			}
 			
 			try {
 				ini_set('html_errors', false);


### PR DESCRIPTION
I don't know when this error was introduced, but XMLImporter's couldn't be created if they required a namespace as the validateXPath function never applies the namespace to it's check.

The commits fixes that issue.
