### PR TITLE
check is_array before implode

### DIFF
--- a/lib/class.xmlimporter.php
+++ b/lib/class.xmlimporter.php
@@ -255,7 +255,9 @@
 
 						if ($type == 'author') {
 							if ($field->get('allow_multiple_selection') == 'no') {
-								$value = array(implode('', $value));
+								if(is_array($value)){
+								        $value = array(implode('', $value));
+								}
 							}
 						}
 


### PR DESCRIPTION
I realize that no one else is probably having this issue, but I don't see the harm in it either. The XML Importer never checks if the value is an array before it attempts to implode it if multiple authors aren't allowed. I know it is in the weeds and if everything were working perfectly you would never have to worry about a string coming in a causing this error, but checking if it is an array first is the difference between me being able to run my importer successfully and it failing with an error.
